### PR TITLE
Add support for PolarSSL/mbed TLS 1.3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ before_install:
 
 install:
   - bundle install
-  - wget https://polarssl.org/download/polarssl-1.3.9-gpl.tgz 
-  - tar -xzvf polarssl-1.3.9-gpl.tgz
-  - cd polarssl-1.3.9 && cmake -D USE_SHARED_POLARSSL_LIBRARY:BOOL=ON . && make && sudo make install
+  - curl -O https://tls.mbed.org/download/mbedtls-1.3.10-gpl.tgz
+  - tar -xzvf mbedtls-1.3.10-gpl.tgz
+  - cd mbedtls-1.3.10 && cmake -D USE_SHARED_MBEDTLS_LIBRARY:BOOL=ON . && make && sudo make install
 
 language: ruby
 
 rvm:
+  - 2.1.2
   - 2.0.0
   - 1.9.3
 

--- a/ext/polarssl/extconf.rb
+++ b/ext/polarssl/extconf.rb
@@ -36,11 +36,11 @@ LIB_DIRS = [
 dir_config('polarssl', HEADER_DIRS, LIB_DIRS)
 
 unless find_header('polarssl/entropy.h')
-  abort "libpolarssl is missing. please install libpolarssl"
+  abort "libpolarssl or libmbedtls is missing. please install libpolarssl"
 end
 
-unless find_library('polarssl', 'entropy_init')
-  abort "libpolarssl is missing.  please install libpolarssl"
+unless find_library('mbedtls', 'entropy_init') || find_library('polarssl', 'entropy_init')
+  abort "libpolarssl or libmbedtls is missing.  please install libpolarssl or libmbedtls"
 end
 
 create_makefile('polarssl/polarssl')


### PR DESCRIPTION
Since PolarSSL was acquired by ARM, they renamed the library from
version 1.3.10 and higher into mbed TLS. This means that the binary
library on systems that install 1.3.10 is called `libmbedtls.a` instead
of `libpolarssl.a`. This changes currently brakes our native extension
building via extconf.

In this commit we add support for both the "old" `libpolarssl` library
name and `libmbedtls` name. This should make this gem compatible with
old PolarSSL versions and all newer mbed TLS versions.

This fixes michiels/polarssl-ruby#9