### PR TITLE
Release 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ PolarSSL for Ruby
 
 <table>
   <tr>
-    <th>PolarSSL version</th>
+    <th>PolarSSL/mbed TLS version</th>
     <th>Gem version</th>
   </tr>
   <tr>
     <td>&lt;= 1.2.x</td><td>0.0.7</td>
   </tr>
   <tr>
-    <td>&gt;= 1.3.x</td><td>1.0.1</td>
+    <td>&gt;= 1.3.0 and &lt; 1.3.10</td><td>1.0.1</td>
+  </tr>
+  <tr>
+    <td>&gt;= 1.3.10</td><td>1.0.2</td>
   </tr>
 </table>
 
@@ -48,7 +51,7 @@ The `-P HighSecurity` will verify signed gems.
 Or in your Gemfile:
 
 ```
-gem "polarssl", "~> 1.0.1"
+gem "polarssl", "~> 1.0.2"
 ```
 
 And install using:

--- a/lib/polarssl/version.rb
+++ b/lib/polarssl/version.rb
@@ -1,5 +1,5 @@
 module PolarSSL
 
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 
 end

--- a/polarssl.gemspec
+++ b/polarssl.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.name = 'polarssl'
   s.version = PolarSSL::VERSION
   s.date = Date.today
-  s.summary = 'Use the PolarSSL cryptographic and SSL library in Ruby.'
-  s.description = 'A gem that lets you use the PolarSSL cryptography library with Ruby.'
+  s.summary = 'Use the PolarSSL (now mbed TLS) cryptographic and SSL library in Ruby.'
+  s.description = 'A gem that lets you use the PolarSSL (now mbed TLS) cryptography library with Ruby.'
   s.authors = ['Michiel Sikkes', 'Oleksandr Iuzikov']
   s.email = 'michiel.sikkes@gmail.com'
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
mbed TLS 1.3.10 has been released. Since that release our gem has been broken. This prepares the release so mbed TLS 1.3.10 works.